### PR TITLE
feat(gocd): GoCD에 파일 기반 인증 추가

### DIFF
--- a/apps/gocd/values.yaml
+++ b/apps/gocd/values.yaml
@@ -43,6 +43,28 @@ gocd:
         key: xquare/platform
         operator: "Equal"
         value: "true"
+
+    persistence:
+      enabled: true
+      extraVolumes:
+        - name: auth-config
+          emptyDir: {}
+
+      extraVolumeMounts:
+        - name: auth-config
+          mountPath: /godata/config/password
+
+    initContainers:
+      - name: create-password-file
+        image: "busybox:latest"
+        command: ["sh", "-c"]
+        args:
+          - |
+            echo "teamxquare:$2y$05$aRLoH6R/gy9Hiw0RW9c.redlwI2zwVun8.7bjWIdvarxFQJI/OBYC" > /godata/config/password/passwd
+        volumeMounts:
+          - name: auth-config
+            mountPath: /godata/config/password
+
     ingress:
       enabled: false
     service:
@@ -51,6 +73,11 @@ gocd:
       extraEnvVars:
         - name: GOCD_PLUGIN_INSTALL_gocd-yaml-config-plugin
           value: https://github.com/tomzo/gocd-yaml-config-plugin/releases/download/v1.0.0-364/yaml-config-plugin-1.0.0-364.jar
+        - name: GOCD_PLUGIN_INSTALL_password-file-auth
+          value: https://github.com/gocd/gocd-filebased-authentication-plugin/releases/download/2.2.0-272/gocd-filebased-authentication-plugin-2.2.0-272.jar
+        - name: GO_SERVER_SYSTEM_PROPERTIES
+          value: "-Dplugin.cd.go.authentication.passwordfile.PasswordFilePath=/godata/config/password/passwd"
+
     resources:
       requests:
         memory: 1024Mi
@@ -142,32 +169,3 @@ gocd:
         - name: aws-credentials
           mountPath: /etc/config/aws/
           readOnly: true
-    initContainers:
-      - name: download-helm
-        image: "ellerbrock/alpine-bash-curl-ssl:latest"
-        imagePullPolicy: "IfNotPresent"
-        volumeMounts:
-          - name: helm
-            mountPath: /download
-        workingDir: /download
-        command: [ "/bin/sh" ]
-        args:
-          - "-c"
-          - |
-            HELM_VERSION=$(curl -s https://api.github.com/repos/helm/helm/releases/latest | grep tag_name | cut -d '"' -f 4) && \
-            curl -LO https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz && \
-            tar -zxvf helm-${HELM_VERSION}-linux-amd64.tar.gz && \
-            mv linux-amd64/helm helm && \
-            chmod +x helm && \
-            mv helm /download/helm
-      - name: download-kubectl
-        image: "ellerbrock/alpine-bash-curl-ssl:latest"
-        imagePullPolicy: "IfNotPresent"
-        volumeMounts:
-          - name: kubectl
-            mountPath: /download
-        workingDir: /download
-        command: [ "/bin/sh" ]
-        args:
-          - "-c"
-          - 'curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x ./kubectl'


### PR DESCRIPTION
GoCD 서버에 파일 기반 인증 플러그인을 설치하고 활성화함.

- `auth-config` 볼륨을 생성하여 패스워드 파일을 저장
- `create-password-file` initContainer를 추가하여 패스워드 파일 생성
- `password-file-auth` 플러그인 설치 및 설정
- GoCD 서버에 필요한 환경 변수 추가

이를 통해 GoCD 서버에 대한 접근 제어를 강화하고 보안을 향상시킴. 기존에는 인증 기능이 없었으므로 누구나 GoCD 서버에 접근 가능했음.
