### PR TITLE
fix(values.yaml): toleration key 수정

### DIFF
--- a/apps/vault/values.yaml
+++ b/apps/vault/values.yaml
@@ -22,7 +22,7 @@ vault:
         cpu: 100m
     tolerations:
       - effect: "NoSchedule"
-        key: xquare/critical
+        key: xquare/critical_platform
         operator: "Equal"
         value: "true"
     affinity: |


### PR DESCRIPTION
toleration key를 `xquare/critical`에서 `xquare/critical_platfrom`으로 변경함

- 이 변경으로 Vault Pod이 의도한 노드에 정확하게 배포되도록 보장
