### PR TITLE
feat :: ArgoCD Vault Plugin 설정 추가

### DIFF
--- a/charts/argocd/templates/avp-credentials-secret.yaml
+++ b/charts/argocd/templates/avp-credentials-secret.yaml
@@ -2,7 +2,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: argocd-vault-plugin-credentials
-  namespace: { { .Release.Namespace } }
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
   AVP_AUTH_TYPE: "k8s"

--- a/charts/argocd/templates/avp-credentials-secret.yaml
+++ b/charts/argocd/templates/avp-credentials-secret.yaml
@@ -1,0 +1,11 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: argocd-vault-plugin-credentials
+  namespace: { { .Release.Namespace } }
+type: Opaque
+stringData:
+  AVP_AUTH_TYPE: "k8s"
+  AVP_K8S_ROLE: "argocd"
+  AVP_TYPE: "vault"
+  VAULT_ADDR: "http://vault.vault.svc.cluster.local:8200"

--- a/charts/argocd/templates/cmp-plugin-configmap.yaml
+++ b/charts/argocd/templates/cmp-plugin-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cmp-plugin
-  namespace: { { .Release.Namespace } }
+  namespace: {{ .Release.Namespace }}
 data:
   plugin.yaml: |
     apiVersion: argoproj.io/v1alpha1

--- a/charts/argocd/templates/cmp-plugin-configmap.yaml
+++ b/charts/argocd/templates/cmp-plugin-configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cmp-plugin
+  namespace: { { .Release.Namespace } }
+data:
+  plugin.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: argocd-vault-plugin-helm
+    spec:
+      allowConcurrency: true
+      discover:
+        find:
+          command:
+            - sh
+            - "-c"
+            - "find . -name 'Chart.yaml' && find . -name 'values.yaml'"
+      init:
+        command:
+          - bash
+          - "-c"
+          - |
+            helm repo add bitnami https://charts.bitnami.com/bitnami
+            helm dependency build
+      generate:
+        command:
+          - sh
+          - "-c"
+          - |
+            helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_HELM_ARGS} . --include-crds |
+            argocd-vault-plugin generate -s argocd:argocd-vault-plugin-credentials -
+      lockRepo: false

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -8,7 +8,7 @@ argo-cd:
     priorityClassName: system-cluster-critical
   configs:
     params:
-      server.insecure: true 
+      server.insecure: true
     cm:
       url: https://argo-cd.xquare.app
       timeout.reconciliation: 15s
@@ -20,7 +20,8 @@ argo-cd:
         clientID: argocd
         clientSecret: DIKHZYN1kolN7d6
         requestedScopes: ["openid", "profile", "email", "groups"]
-      resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration: |
+      resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration:
+        |
         jqPathExpressions:
         - '.webhooks[]?.clientConfig.caBundle'
     rbac:
@@ -32,7 +33,7 @@ argo-cd:
       requests:
         cpu: 1m
         memory: 32Mi
-  dex: 
+  dex:
     enabled: false
   notifications:
     enabled: false
@@ -47,6 +48,54 @@ argo-cd:
       requests:
         cpu: 3m
         memory: 64Mi
+    rbac:
+      - verbs: ["get", "list", "watch"]
+        apiGroups: [""]
+        resources: ["secrets", "configmaps"]
+
+    initContainers:
+      - name: download-tools
+        image: alpine/curl
+        env:
+          - name: AVP_VERSION
+            value: "1.18.1"
+        command: [sh, -c]
+        args:
+          - >-
+            curl -L https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v$(AVP_VERSION)/argocd-vault-plugin_$(AVP_VERSION)_linux_amd64 -o argocd-vault-plugin &&
+            chmod +x argocd-vault-plugin &&
+            mv argocd-vault-plugin /custom-tools/
+        volumeMounts:
+          - mountPath: /custom-tools
+            name: custom-tools
+
+    extraContainers:
+      - name: avp-helm
+        command: ["/var/run/argocd/argocd-cmp-server"]
+        image: quay.io/argoproj/argocd:v2.13.2
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 999
+        volumeMounts:
+          - mountPath: /var/run/argocd
+            name: var-files
+          - mountPath: /home/argocd/cmp-server/plugins
+            name: plugins
+          - mountPath: /tmp
+            name: tmp-dir
+          - mountPath: /home/argocd/cmp-server/config
+            name: cmp-plugin
+          - name: custom-tools
+            subPath: argocd-vault-plugin
+            mountPath: /usr/local/bin/argocd-vault-plugin
+    volumes:
+      - configMap:
+          name: cmp-plugin
+        name: cmp-plugin
+      - name: custom-tools
+        emptyDir: {}
+      - name: tmp-dir
+        emptyDir: {}
   controller:
     resources:
       requests:
@@ -57,4 +106,3 @@ argo-cd:
       requests:
         cpu: 32m
         memory: 516Mi
-  


### PR DESCRIPTION
ArgoCD에서 Helm Chart 배포 시 Vault Plugin을 사용하기 위한 설정 추가

- `argocd-vault-plugin`을 사용하기 위한 `Secret`, `ConfigMap` 생성
- `values.yaml`에 Vault Plugin 관련 설정 추가
- `argocd-vault-plugin` binary를 다운로드하고 사용하도록 설정
- Vault Plugin을 통해 Secret을 관리하고 Chart 배포 시 사용 가능하도록 구성