### PR TITLE
feat :: vault-aws-kms-auto-unseal 기능 추가

### DIFF
--- a/apps/vault/templates/configmap-seal.yaml
+++ b/apps/vault/templates/configmap-seal.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vault-seal-config
+  namespace: vault
+data:
+  seal.hcl: |
+    seal "awskms" {
+      region     = "ap-northeast-2"
+      kms_key_id = "alias/vault-auto-unseal-key"
+    }

--- a/apps/vault/values.yaml
+++ b/apps/vault/values.yaml
@@ -35,6 +35,24 @@ vault:
     volumeMounts:
       - mountPath: "/vault/data"
         name: vault-storage
+
+    extraEnvironmentVars:
+      VAULT_SEAL_TYPE: awskms
+      AWS_REGION: ap-northeast-2
+      VAULT_AWSKMS_SEAL_KEY_ID: alias/vault-auto-unseal-key
+
+    extraArgs:
+      - "-config=/vault/config/seal.hcl"
+
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: "arn:aws:iam::786584124104:role/vault-kms-role"
+
+    extraVolumes:
+      - type: configMap
+        name: vault-seal-config
+        path: /vault/config
+
   pod:
     affinity: |
     tolerations:


### PR DESCRIPTION
Vault 서버의 자동 봉인해제를 위해 AWS KMS를 사용하도록 설정 추가

- `awskms` seal 설정을 위한 configmap과 설정 추가
- Vault 컨테이너에 KMS 접근 권한을 위한 ServiceAccount 설정 추가
- Vault 서버 재시작시 자동으로 unseal 되도록 설정