### PR TITLE
feat :: external-dns chart 추가

### DIFF
--- a/apps/external-dns/Chart.yaml
+++ b/apps/external-dns/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: external-dns
+description: A Helm chart for External-DNS
+type: application
+version: 1.0.0
+appVersion: "v0.16.1"
+dependencies:
+  - name: external-dns
+    version: 1.13.1
+    repository: https://kubernetes-sigs.github.io/external-dns/

--- a/apps/external-dns/values.yaml
+++ b/apps/external-dns/values.yaml
@@ -1,0 +1,15 @@
+provider: cloudflare
+
+env:
+  - name: CF_API_TOKEN
+    value: <path:avp/data/cloudflare/external-dns#CF_API_TOKEN>
+
+sources:
+  - istio-virtualservice
+  - ingress
+
+tolerations:
+  - effect: "NoSchedule"
+    key: xquare/platform
+    operator: "Equal"
+    value: "true"

--- a/apps/external-dns/values.yaml
+++ b/apps/external-dns/values.yaml
@@ -1,15 +1,16 @@
-provider: cloudflare
+external-dns:
+  provider: cloudflare
 
-env:
-  - name: CF_API_TOKEN
-    value: <path:avp/data/cloudflare/external-dns#CF_API_TOKEN>
+  env:
+    - name: CF_API_TOKEN
+      value: <path:avp/data/cloudflare/external-dns#CF_API_TOKEN>
 
-sources:
-  - istio-virtualservice
-  - ingress
+  sources:
+    - istio-virtualservice
+    - ingress
 
-tolerations:
-  - effect: "NoSchedule"
-    key: xquare/platform
-    operator: "Equal"
-    value: "true"
+  tolerations:
+    - effect: "NoSchedule"
+      key: xquare/platform
+      operator: "Equal"
+      value: "true"

--- a/charts/xquare-application/Chart.yaml
+++ b/charts/xquare-application/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 type: application
 name: xquare-application
-version: 1.1.13
+version: 1.1.14
 appVersion: "1.0.0"
 description: Xquare application

--- a/charts/xquare-application/values.yaml
+++ b/charts/xquare-application/values.yaml
@@ -156,6 +156,15 @@ projects:
           automated:
             prune: false
             selfHeal: true
+      - name: external-dns
+        namespace: external-dns
+        source:
+          path: apps/external-dns
+          repoURL: https://github.com/team-xquare/k8s-resource.git
+        syncPolicy:
+          automated:
+            prune: false
+            selfHeal: true
       #      - name: percona-operator
       #        namespace: percona
       #        source:


### PR DESCRIPTION
external-dns를 사용하기 위한 chart를 추가

- cloudflare provider를 사용하도록 설정
- istio-virtualservice와 ingress를 source로 설정