### PR TITLE
Remove duplicate club entries

### DIFF
--- a/apps/xquare-club/values.yaml
+++ b/apps/xquare-club/values.yaml
@@ -22,7 +22,6 @@ clubs:
   - name: kook
   - name: founderz
   - name: superbad
-  - name: daedongyeojido
   - name: cuberlabs
   - name: daemaru
   - name: mozu


### PR DESCRIPTION
## 변경 사항
- `clubs` 리스트에서 중복된 `daedongyeojido` 항목을 제거했습니다.

## 변경 이유
- 중복된 클럽 이름으로 인해 `Resource /Namespace//daedongyeojido-prod appeared 2 times among application resources.` 오류가 발생하였습니다.
- 중복 항목을 제거하여 올바른 데이터 구조를 유지하고, 불필요한 리소스 중복 배포를 방지합니다.