### PR TITLE
feat : Add Datadog monitoring configuration for Kubernetes

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/apps/datadog-resource/Chart.yaml
+++ b/apps/datadog-resource/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: datadog-monitors
+description: Datadog monitors for Kubernetes
+type: application
+version: 1.0.0
+appVersion: "1.0.0"

--- a/apps/datadog-resource/templates/monitors.yaml
+++ b/apps/datadog-resource/templates/monitors.yaml
@@ -1,0 +1,45 @@
+{{- range .Values.monitors }}
+---
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogMonitor
+metadata:
+  name: {{ .name }}
+spec:
+  type: {{ .type }}
+  query: {{ .query }}
+  message: {{ .message }}
+  {{- if .tags }}
+  tags:
+  {{- range .tags }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if .options }}
+  options:
+    {{- if .options.thresholds }}
+    thresholds:
+      {{- if .options.thresholds.critical }}
+      critical: {{ .options.thresholds.critical }}
+      {{- end }}
+      {{- if .options.thresholds.warning }}
+      warning: {{ .options.thresholds.warning }}
+      {{- end }}
+    {{- end }}
+    notify_no_data: {{ .options.notify_no_data | default false }}
+    require_full_window: {{ .options.require_full_window | default false }}
+    notify_audit: {{ .options.notify_audit | default false }}
+    include_tags: {{ .options.include_tags | default true }}
+    {{- if .options.evaluation_delay }}
+    evaluation_delay: {{ .options.evaluation_delay }}
+    {{- end }}
+    {{- if .options.new_host_delay }}
+    new_host_delay: {{ .options.new_host_delay }}
+    {{- end }}
+    {{- if .options.renotify_interval }}
+    renotify_interval: {{ .options.renotify_interval }}
+    {{- end }}
+    {{- if .options.no_data_timeframe }}
+    no_data_timeframe: {{ .options.no_data_timeframe }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/apps/datadog-resource/values.yaml
+++ b/apps/datadog-resource/values.yaml
@@ -1,0 +1,101 @@
+monitors:
+  - name: "kubernetes-high-cpu-usage"
+    type: "metric alert"
+    query: "avg(last_5m):avg:system.cpu.user{kubernetes_cluster:xquare-v3-cluster} by {host} > 80"
+    message: |
+      CPU usage is above 80% on {{host.name}}
+      
+      @slack-xquare-monitoring
+    tags:
+      - "service:kubernetes"
+      - "env:production"
+    options:
+      thresholds:
+        critical: 80
+        warning: 70
+      notify_no_data: false
+      require_full_window: false
+      new_host_delay: 300
+      renotify_interval: 60
+      include_tags: true
+      evaluation_delay: 900
+
+  - name: "kubernetes-high-memory-usage"
+    type: "metric alert"
+    query: "avg(last_5m):avg:system.mem.pct_usable{kubernetes_cluster:xquare-v3-cluster} by {host} < 0.2"
+    message: |
+      Memory usage is critical on {{host.name}}
+      
+      @slack-xquare-monitoring
+    tags:
+      - "service:kubernetes"
+      - "env:production"
+    options:
+      thresholds:
+        critical: 0.2
+        warning: 0.3
+      notify_no_data: false
+      require_full_window: false
+      new_host_delay: 300
+      renotify_interval: 60
+      include_tags: true
+      evaluation_delay: 900
+
+  - name: "kubernetes-high-disk-usage"
+    type: "metric alert"
+    query: "avg(last_5m):avg:system.disk.in_use{kubernetes_cluster:xquare-v3-cluster} by {host,device} > 0.85"
+    message: |
+      Disk usage is above 85% on {{host.name}} ({{device.name}})
+      
+      @slack-xquare-monitoring
+    tags:
+      - "service:kubernetes"
+      - "env:production"
+    options:
+      thresholds:
+        critical: 0.85
+        warning: 0.75
+      notify_no_data: false
+      require_full_window: false
+      new_host_delay: 300
+      renotify_interval: 60
+      include_tags: true
+      evaluation_delay: 900
+
+  - name: "kubernetes-node-not-ready"
+    type: "metric alert"
+    query: "avg(last_5m):sum:kubernetes_state.node.condition{kubernetes_cluster:xquare-v3-cluster,condition:ready,status:true} < 3"
+    message: |
+      Less than 3 Kubernetes nodes are in Ready state!
+      
+      @slack-xquare-monitoring
+    tags:
+      - "service:kubernetes"
+      - "env:production"
+    options:
+      thresholds:
+        critical: 3
+      notify_no_data: true
+      no_data_timeframe: 10
+      require_full_window: false
+      include_tags: true
+      evaluation_delay: 60
+
+  - name: "kubernetes-pending-pods"
+    type: "metric alert"
+    query: "sum(last_10m):sum:kubernetes_state.pod.status_phase{kubernetes_cluster:xquare-v3-cluster,phase:pending} > 5"
+    message: |
+      There are more than 5 pods in pending state in the cluster
+      
+      @slack-xquare-monitoring
+    tags:
+      - "service:kubernetes"
+      - "env:production"
+    options:
+      thresholds:
+        critical: 5
+        warning: 3
+      notify_no_data: false
+      require_full_window: false
+      include_tags: true
+      evaluation_delay: 60

--- a/charts/xquare-application/values.yaml
+++ b/charts/xquare-application/values.yaml
@@ -210,3 +210,12 @@ projects:
       #          automated:
       #            prune: false
       #            selfHeal: true
+      - name: datadog-resource
+        namespace: monitoring
+        source:
+          path: apps/datadog-resource
+          repoURL: https://github.com/team-xquare/k8s-resource.git
+        syncPolicy:
+          automated:
+            prune: false
+            selfHeal: true


### PR DESCRIPTION
datadog 모니터를 helm chart 로 관리하게 합니다

This pull request introduces a new Helm chart for Datadog monitors and includes updates to the Kubernetes configuration to integrate these monitors. The most important changes include the creation of the Helm chart, the definition of Datadog monitor templates, and the addition of specific monitor configurations.

### Helm Chart for Datadog Monitors:
* [`apps/datadog-resource/Chart.yaml`](diffhunk://#diff-1dd92a381063432242fba43b9c268ce48ff4b023751f72bf70a8b83cba4b03c8R1-R6): Added a new Helm chart definition for Datadog monitors, including metadata such as `apiVersion`, `name`, `description`, `type`, `version`, and `appVersion`.

### Datadog Monitor Templates:
* [`apps/datadog-resource/templates/monitors.yaml`](diffhunk://#diff-e74cc548bda07772b323c08ae35bad81ca88819f15882402ad498df9060bb167R1-R45): Introduced templates for defining Datadog monitors using Helm, allowing for dynamic configuration of monitor properties such as `type`, `query`, `message`, `tags`, and `options`.

### Monitor Configurations:
* [`apps/datadog-resource/values.yaml`](diffhunk://#diff-4d5ad2089de1bbd0880d2443a8426b0a8445b9d8e7ef317031b0dd42bbace97aR1-R101): Added specific Datadog monitor configurations for high CPU usage, high memory usage, high disk usage, node readiness, and pending pods. Each monitor includes detailed settings for thresholds, notifications, and evaluation delays.

### Kubernetes Configuration:
* [`charts/xquare-application/values.yaml`](diffhunk://#diff-6d8baadcd7cd909cf0a2b496d45724204b96e3f5a148b60cea97796adb39c21fR213-R221): Updated the Kubernetes configuration to include the new `datadog-resource` project, specifying its namespace, source path, and synchronization policy.

### VCS Configuration:
* [`.idea/vcs.xml`](diffhunk://#diff-a6dab70bd0e9ffc91d8419ad52225baff3a3e7c9d8e1724f7ed6d96b661d804aR5): Added a mapping for the project directory to use Git for version control.