### PR TITLE
Enable password login for Argo Workflows

### DIFF
--- a/apps/dex/values.yaml
+++ b/apps/dex/values.yaml
@@ -7,7 +7,16 @@ dex:
       type: memory
     oauth2:
       responseTypes: ["code", "token", "id_token"]
-      skipApprovalScreen: true 
+      skipApprovalScreen: true
+    {{- $dexAdminEmail := "<path:avp/data/dex/admin#email>" }}
+    {{- $dexAdminHash := "<path:avp/data/dex/admin#hash>" }}
+    {{- $dexAdminUser := "<path:avp/data/dex/admin#username>" }}
+    {{- $dexAdminID := "<path:avp/data/dex/admin#userID>" }}
+    staticPasswords:
+    - email: {{$dexAdminEmail}}
+      hash: {{$dexAdminHash}}
+      username: {{$dexAdminUser}}
+      userID: {{$dexAdminID}}
     staticClients:
     - id: xquare  
       name: 'xquare'


### PR DESCRIPTION
## Summary
- allow Dex to provide local user credentials for Argo Workflows
- use argocd-vault-plugin to source credentials from Vault

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68524edc77148324abe131bba71af345